### PR TITLE
Added guzzle support

### DIFF
--- a/DependencyInjection/Compiler/AdapterCompilerPass.php
+++ b/DependencyInjection/Compiler/AdapterCompilerPass.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the HBStampieBundle package.
+ *
+ * (c) Henrik Bjornskov <henrik@bjrnskov.dk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace HB\StampieBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class AdapterCompilerPass
+ * @package HB\StampieBundle\DependencyInjection\Compiler
+ */
+class AdapterCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $adapterMapping = array(
+            'buzz' =>'hb_stampie.adapter.buzz',
+            'guzzle.client' => 'hb_stampie.adapter.guzzle'
+        );
+
+        $this->addAdapterIfAvailable($container, $adapterMapping);
+    }
+
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array $adapterMapping
+     */
+    private function addAdapterIfAvailable(ContainerBuilder $container, array $adapterMapping)
+    {
+        foreach ($adapterMapping as $serviceId => $adapterId) {
+            if ($container->has($serviceId)) {
+                $container->getDefinition($adapterId)
+                    ->addArgument(new Reference($serviceId));
+            }
+        }
+    }
+}

--- a/HBStampieBundle.php
+++ b/HBStampieBundle.php
@@ -10,10 +10,21 @@
  */
 
 namespace HB\StampieBundle;
+use HB\StampieBundle\DependencyInjection\Compiler\AdapterCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @author Henrik Bjornskov <henrik@bjrnskov.dk>
  */
 class HBStampieBundle extends \Symfony\Component\HttpKernel\Bundle\Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new AdapterCompilerPass());
+    }
 }

--- a/README.md
+++ b/README.md
@@ -12,13 +12,16 @@ Add the configuration to `config.yml` as follows
 
 ``` yaml
 hb_stampie:
-    adapter: buzz # buzz and noop are supported
+    adapter: buzz # buzz, guzzle and noop are supported
     mailer: postmark # [send_grid, mail_chimp, postmark] is supported
     server_token: POSTMARK_API_TEST # Replace with your ServerToken for you Service
 ```
 
 For the `buzz` adapter to work it is required to have a `buzz` service fortunately [SensioBuzzBundle](http://github.com/sensio/SensioBuzzBundle)
 provides this.
+
+If you want to use the `guzzle` adapter, the [MisdGuzzleBundle](https://github.com/misd-service-development/guzzle-bundle) provides
+the required dependencies.
 
 ## StampieExtra
 

--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -15,13 +15,19 @@
 
         <!-- Adapters -->
         <parameter key="hb_stampie.adapter.buzz.class">Stampie\Adapter\Buzz</parameter>
+        <parameter key="hb_stampie.adapter.guzzle.class">Stampie\Adapter\Guzzle</parameter>
         <parameter key="hb_stampie.adapter.noop.class">Stampie\Adapter\NoopAdapter</parameter>
     </parameters>
 
     <services>
+
         <!-- Adapters -->
         <service id="hb_stampie.adapter.buzz" class="%hb_stampie.adapter.buzz.class%">
-            <argument type="service" id="buzz" />
+            <argument><!-- Injected in AdapterCompilerPass --></argument>
+        </service>
+
+        <service id="hb_stampie.adapter.guzzle" class="%hb_stampie.adapter.guzzle.class%">
+            <argument><!-- Injected in AdapterCompilerPass --></argument>
         </service>
 
         <service id="hb_stampie.adapter.noop" class="%hb_stampie.adapter.noop.class%" />


### PR DESCRIPTION
Moved adapter configuration to `AdapterCompilerPass` to avoid exceptions if `buzz` or `guzzle` dependencies are not present.

