### PR TITLE
Fix the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "target-dir" : "HB/StampieBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "0.1.x-dev"
+            "dev-master": "1.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
The bundle was released as 1.0.0 and 1.0.1 so the branch alias was wrong